### PR TITLE
Updates Makefile to properly build lcpchecker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR=$(ROOT_DIR)/build
 UNAME_S= $(shell uname -s)
 ARCH=amd64
 
-lcpchecker=cmd/lcpchecker.go
+lcpchecker=cmd/lcpchecker/lcpchecker.go
 
 #LDFLAGS=-ldflags '-linkmode external -w -extldflags "-static"'
 LDFLAGS=

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A lightweight content management server will also be released, named `pubstore`,
 
 Before these tools are available, the current Encryption Tool and Test Frontend Server will be usable with this new lcp-server (their API will be adapted to do so).
 
+`lcpchecker`:
+ * Simply run `make` in the root of this repository; The binary will be output to `build/bin/lcpchecker` by default.
+
 ## Configuration
 
 The configuration is similar to the v1 config, but simplified. 


### PR DESCRIPTION
This updates the `Makefile` to point at `lcpchecker` properly.

Also adds a note in the readme around lcpchecker, and updates `.gitignore` to not care about the build directory.